### PR TITLE
[limen GEN-a-organvm-petasum-super-petasum-ci-green-0620] Make a-organvm/petasum-super-petasum CI green

### DIFF
--- a/src/governance.py
+++ b/src/governance.py
@@ -51,7 +51,7 @@ class GovernanceReport:
     checks: list[HealthCheck] = field(default_factory=list)
 
     @classmethod
-    def from_engine_audit(cls, result: _EngineAuditResult) -> "GovernanceReport":
+    def from_engine_audit(cls, result: Any) -> "GovernanceReport":
         """Build a local report from a canonical organvm-engine audit result."""
         report = cls()
         for item in getattr(result, "critical", []):

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date
 from enum import Enum
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -6,15 +6,13 @@ import json
 import os
 import tempfile
 
-from src.__main__ import cmd_audit, cmd_evaluate, cmd_report, load_registry, main
+from src.__main__ import load_registry, main
 from src.governance import (
     GovernanceReport,
     HealthCheck,
     check_ci_health,
     check_documentation_coverage,
 )
-from src.report import generate_organ_report, generate_system_report
-from src.tracker import ObligationStatus, ObligationTracker, PromotionObligation
 
 
 def _write_registry(repos: list[dict]) -> str:


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-a-organvm-petasum-super-petasum-ci-green-0620`.

Inspect the latest FAILING checks on a-organvm/petasum-super-petasum's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-20 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._