### PR TITLE
[limen GEN-a-organvm-petasum-super-petasum-ci-green-0620] Make a-organvm/petasum-super-petasum CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -30,7 +29,6 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Lint with ruff
-        continue-on-error: true
         run: ruff check --output-format=github .
 
       - name: Type check with pyright
@@ -39,4 +37,4 @@ jobs:
           pyright src/
 
       - name: Test with pytest
-        run: pytest --cov=src --cov-report=term -v || echo "::warning::pytest failed"
+        run: pytest --cov=src --cov-report=term -v


### PR DESCRIPTION
Autonomous **limen** dispatch of task `GEN-a-organvm-petasum-super-petasum-ci-green-0620`.

Inspect the latest FAILING checks on a-organvm/petasum-super-petasum's default branch, fix the root cause (lint / types / failing test / config), and confirm the checks pass. If CI is already green, add the single most valuable missing check (e.g. typecheck or test-matrix) instead. [auto-generated 2026-06-20 to keep the stream endless]

_Produced in an isolated worktree off origin — review before merge._