### PR TITLE
feat: align RFC template with the Logic-First Framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/org-rfc.yml
+++ b/.github/ISSUE_TEMPLATE/org-rfc.yml
@@ -3,6 +3,15 @@ description: Propose a cross-repo change for review.
 title: "[RFC] <short title>"
 labels: [org-wide, rfc, needs-triage]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Logic-First Framework
+
+        This RFC should adhere to the repository's **Logic-First Framework**
+        (see [`docs/LOGIC_FRAMEWORK.md`](../../docs/LOGIC_FRAMEWORK.md)): ground the
+        proposal in explicit **premises**, sound **reasoning**, and a clear
+        **conclusion**, rather than assertion or preference.
   - type: textarea
     id: summary
     attributes:
@@ -13,13 +22,18 @@ body:
     id: motivation
     attributes:
       label: Motivation
-      placeholder: Why is this needed? Who benefits?
+      description: State your premises — the facts and assumptions this proposal starts from — and the reasoning that follows from them.
+      placeholder: |
+        Premise: ...
+        Premise: ...
+        Reasoning: therefore, ...
     validations:
       required: true
   - type: textarea
     id: design
     attributes:
       label: Design/Approach
+      description: The conclusion your premises and reasoning lead to. Note where it aligns with (or is an exception to) the Logic-First Framework.
       placeholder: Architecture, alternatives, rollout plan
     validations:
       required: true


### PR DESCRIPTION
## What

The org-wide **RFC issue template** now references and enforces the repo's own **Logic-First Framework** (`docs/LOGIC_FRAMEWORK.md`).

## Why

The RFC form collected Summary / Motivation / Design / Impact / Risks / Metrics, but never tied proposals to the Logic-First governance philosophy this repo encodes. This distills the recurring **Palette** RFC-template want raised across several Jules-authored PRs — #10, #14, #20, #26, #29 — into the current template with the correct doc path, rather than merging any one stale draft.

## Changes

- `.github/ISSUE_TEMPLATE/org-rfc.yml`: a Logic-First markdown intro (links `docs/LOGIC_FRAMEWORK.md`); Motivation now prompts explicit **premises + reasoning**; Design is framed as the **conclusion** they lead to. YAML validated.

Supersedes the intent of #10/#14/#20/#26/#29 (kept open per the never-close doctrine; each cross-linked).